### PR TITLE
Fixed travis build status icon which was png instead of svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Lavagna
 
 [![Join the chat at https://gitter.im/digitalfondue/lavagna](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/digitalfondue/lavagna?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![Build Status](https://travis-ci.org/digitalfondue/lavagna.png?branch=master)](https://travis-ci.org/digitalfondue/lavagna)
+[![Build Status](https://travis-ci.org/digitalfondue/lavagna.svg?branch=master)](https://travis-ci.org/digitalfondue/lavagna)
 [![Coverage Status](https://coveralls.io/repos/digitalfondue/lavagna/badge.svg?branch=master)](https://coveralls.io/r/digitalfondue/lavagna?branch=master)
 [![Maven Central](https://img.shields.io/maven-central/v/io.lavagna/lavagna.svg)](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22lavagna%22)
 [![Docker Status](https://img.shields.io/docker/pulls/digitalfondue/lavagna.svg)](https://registry.hub.docker.com/u/digitalfondue/lavagna/)


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/3884632/12041961/9c342526-ae76-11e5-85d7-4ec982f1e349.png)

After:
![image](https://cloud.githubusercontent.com/assets/3884632/12041976/b2d94338-ae76-11e5-831b-d6a45240f80d.png)

Due to compression, the difference is hard to spot, but a closer look reveals the improvement :)