### PR TITLE
Calendar feed: use UTC in card and milestone due date

### DIFF
--- a/src/main/java/io/lavagna/service/calendarutils/CalendarVEventHandler.java
+++ b/src/main/java/io/lavagna/service/calendarutils/CalendarVEventHandler.java
@@ -20,10 +20,7 @@ package io.lavagna.service.calendarutils;
 import io.lavagna.model.*;
 import io.lavagna.service.CardDataService;
 import io.lavagna.service.UserRepository;
-import net.fortuna.ical4j.model.Date;
-import net.fortuna.ical4j.model.DateTime;
-import net.fortuna.ical4j.model.Dur;
-import net.fortuna.ical4j.model.Property;
+import net.fortuna.ical4j.model.*;
 import net.fortuna.ical4j.model.component.VAlarm;
 import net.fortuna.ical4j.model.component.VEvent;
 import net.fortuna.ical4j.model.parameter.Cn;
@@ -135,8 +132,13 @@ public class CalendarVEventHandler implements CalendarEventHandler {
         // Organizer
         UserDescription ud = getUserDescription(card.getCreationUser(), usersCache);
 
-        final VEvent event = new VEvent(new Date(lav.getLabelValueTimestamp()), name);
-        event.getProperties().getProperty(Property.DTSTART).getParameters().add(Value.DATE);
+        TimeZoneRegistry registry = TimeZoneRegistryFactory.getInstance().createRegistry();
+        TimeZone timezone = registry.getTimeZone("Z");
+
+        DateTime dueDate = new DateTime(lav.getLabelValueTimestamp());
+        dueDate.setUtc(true);
+        final VEvent event = new VEvent(dueDate, name);
+        event.getProperties().getProperty(Property.DTSTART).getParameters().add(Value.DATE_TIME);
 
         event.getProperties().add(new Created(new DateTime(card.getCreationDate())));
         event.getProperties().add(new LastModified(new DateTime(card.getLastUpdateTime())));

--- a/src/main/java/io/lavagna/service/calendarutils/CalendarVEventHandler.java
+++ b/src/main/java/io/lavagna/service/calendarutils/CalendarVEventHandler.java
@@ -131,10 +131,7 @@ public class CalendarVEventHandler implements CalendarEventHandler {
 
         // Organizer
         UserDescription ud = getUserDescription(card.getCreationUser(), usersCache);
-
-        TimeZoneRegistry registry = TimeZoneRegistryFactory.getInstance().createRegistry();
-        TimeZone timezone = registry.getTimeZone("Z");
-
+        
         DateTime dueDate = new DateTime(lav.getLabelValueTimestamp());
         dueDate.setUtc(true);
         final VEvent event = new VEvent(dueDate, name);

--- a/src/main/java/io/lavagna/service/calendarutils/CalendarVEventHandler.java
+++ b/src/main/java/io/lavagna/service/calendarutils/CalendarVEventHandler.java
@@ -100,8 +100,10 @@ public class CalendarVEventHandler implements CalendarEventHandler {
 
         final UUID id = new UUID(getLong(m.getCardLabelId(), m.getId()), getLong(m.getOrder(), 0));
 
-        final VEvent event = new VEvent(new Date(date.getTime()), name);
-        event.getProperties().getProperty(Property.DTSTART).getParameters().add(Value.DATE);
+        DateTime dueDate = new DateTime(date.getTime());
+        dueDate.setUtc(true);
+        final VEvent event = new VEvent(dueDate, name);
+        event.getProperties().getProperty(Property.DTSTART).getParameters().add(Value.DATE_TIME);
 
         event.getProperties().add(new Description(descBuilder.toString()));
 
@@ -131,7 +133,7 @@ public class CalendarVEventHandler implements CalendarEventHandler {
 
         // Organizer
         UserDescription ud = getUserDescription(card.getCreationUser(), usersCache);
-        
+
         DateTime dueDate = new DateTime(lav.getLabelValueTimestamp());
         dueDate.setUtc(true);
         final VEvent event = new VEvent(dueDate, name);


### PR DESCRIPTION
This PR intends to fix an issue close to #70: when loading the calendar feed into a calendar application, due dates have no timezone indication and thus may appear earlier or later than the actual date .

For example, when I set a due date for 2017-04-03, my server which is in the Europe/Paris timezone outputs a calendar entry such as:

````
BEGIN:VEVENT
DTSTAMP:20170402T154957Z
DTSTART;VALUE=DATE;VALUE=DATE:20170402
SUMMARY:TECH-24 Test notification 2 (OPEN)
CREATED:20170402T145334Z
LAST-MODIFIED:20170402T153717Z
UID:00000005-0000-0018-0000-000600000006
ORGANIZER;CN=datafaber:MAILTO:admin@datafaber.net
URL:https://tasks.datafaber.net/BASE/TECH-24
DESCRIPTION:Test notification in progress
BEGIN:VALARM
TRIGGER:PT0S
ACTION:DISPLAY
DESCRIPTION:TECH-24 Test notification 2 (OPEN)
END:VALARM
END:VEVENT
````

where the actual due date appears in the JSON responses from Lavagna as:

````
            "labelColor": 0,
            "labelDomain": "SYSTEM",
            "labelId": 6,
            "labelName": "DUE_DATE",
            "labelProjectId": 2,
            "labelType": "TIMESTAMP",
            "labelUnique": true,
            "labelValueCard": null,
            "labelValueCardId": 24,
            "labelValueId": 6,
            "labelValueInt": null,
            "labelValueLabelId": 6,
            "labelValueList": null,
            "labelValueString": null,
            "labelValueTimestamp": "2017-04-02T22:00:00.000Z",
            "labelValueType": "TIMESTAMP",
            "labelValueUseUniqueIndex": true,
            "labelValueUser": null,
            "value": {
                "valueCard": null,
                "valueInt": null,
                "valueList": null,
                "valueString": null,
                "valueTimestamp": "2017-04-02T22:00:00.000Z",
                "valueUser": null
            }
````

The 2-hours difference with GMT and the loss of the time component make calendar applications believe that this due date is Apr, 2 2017 at midnight, which is a day earlier than intended.

Due dates for milestones have the same issue.

With the changes from this pull request, due dates for cards and milestones are exported in UTC time so that calendar applications can correctly display dates and reminders.