### PR TITLE
Adds the ldap user check before create a new entry in the database

### DIFF
--- a/src/main/java/io/lavagna/config/WebSecurityConfig.java
+++ b/src/main/java/io/lavagna/config/WebSecurityConfig.java
@@ -204,6 +204,7 @@ public class WebSecurityConfig {
         }
 
         public void createIfConfiguredAndMissing(String provider, String name) {
+
             if (canLdap(provider, name) || canOauth(provider, name)) {
                 createDefaultUser(provider, name);
             }
@@ -303,6 +304,10 @@ public class WebSecurityConfig {
             @Override
             public boolean authenticate(String username, String password) {
                 return ldap.authenticate(username, password);
+            }
+            @Override
+            public boolean checkUserAvailability(String username) {
+                return ldap.checkUserAvailability(username);
             }
         };
 

--- a/src/main/java/io/lavagna/web/security/login/LdapLogin.java
+++ b/src/main/java/io/lavagna/web/security/login/LdapLogin.java
@@ -69,7 +69,7 @@ public class LdapLogin extends AbstractLoginHandler {
 	}
 
 	private boolean authenticate(String username, String password) {
-		if (StringUtils.isEmpty(username) || StringUtils.isEmpty(password) || !users.userExistsAndEnabled(USER_PROVIDER, username)) {
+		if (StringUtils.isEmpty(username) || StringUtils.isEmpty(password) || !ldap.checkUserAvailability(username) || !users.userExistsAndEnabled(USER_PROVIDER, username)) {
 			return false;
 		}
 
@@ -85,6 +85,7 @@ public class LdapLogin extends AbstractLoginHandler {
 
 	public interface LdapAuthenticator {
 	    boolean authenticate(String username, String password);
+	    boolean checkUserAvailability(String username);
 	}
 
     @Override


### PR DESCRIPTION
In case of LDAP Authentication users are created even if they don't exist in the LDAP. This fix tries to solve this problem by checking the user existence before authentication.